### PR TITLE
Supporting setups where Wordpress is not initialized immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ composer require djboris88/timber-commented-include --dev
 
 Usage
 -----
-To be able to see the commented output, `WP_DEBUG` has to be defined and set as 
-`true` in `wp-config.php` file. The Twig Extension will automatically be registered
-and applied.
+To be able to see the commented output, `WP_DEBUG` has to be defined and set as
+`true` in `wp-config.php` file.
+
+The Twig Extension will automatically be registered and applied. If the
+WordPress add_filter function is not available when that happens, it will fail.
+In that case, you will need to call initialization yourself at an appropriate
+time after WordPress itself is initialized:
+```php
+if (function_exists('\Djboris88\Timber\initialize_filters')) {
+  \Djboris88\Timber\initialize_filters();
+}
+```

--- a/functions.php
+++ b/functions.php
@@ -24,14 +24,29 @@ function add_commented_include_extension($twig)
 	return $twig;
 }
 
-if (defined('WP_DEBUG') && WP_DEBUG && function_exists('add_filter')) {
-	add_filter('timber/loader/twig', sprintf('%s\\add_commented_include_extension', __NAMESPACE__));
+/**
+ * Tries to initialize the twig extension, if it has not been already.
+ */
+function initialize_filters()
+{
+	if (
+		!defined('WP_DJBORIS88_TIMBER_FILTERS_INITIALIZED')
+		&& defined('WP_DEBUG')
+		&& WP_DEBUG
+		&& function_exists('add_filter')
+	) {
+		define('WP_DJBORIS88_TIMBER_FILTERS_INITIALIZED', TRUE);
 
-	/**
-	 * Adding a second filter to cover the `Timber::render()` case, when the
-	 * template is not loaded through the `include` tag inside a twig file
-	 */
-	add_filter( 'timber/output', function( $output, $data, $file ) {
-		return "\n<!-- Begin output of '" . $file . "' -->\n" . $output . "\n<!-- / End output of '" . $file . "' -->\n";
-	}, 10, 3 );
+		add_filter('timber/loader/twig', sprintf('%s\\add_commented_include_extension', __NAMESPACE__));
+
+		/**
+		 * Adding a second filter to cover the `Timber::render()` case, when the
+		 * template is not loaded through the `include` tag inside a twig file
+		 */
+		add_filter( 'timber/output', function( $output, $data, $file ) {
+			return "\n<!-- Begin output of '" . $file . "' -->\n" . $output . "\n<!-- / End output of '" . $file . "' -->\n";
+		}, 10, 3 );
+	}
 }
+
+initialize_filters();


### PR DESCRIPTION
Thank you for the nifty extension!

I ran into an issue trying to use this on a project where WordPress is not immediately initialized. If either add_filter() or WP_DEBUG is not yet defined, the chance to add the the relevant filters is missed and the extension is not used.

Here's a pull request that wraps the initialization code in a function. The extension should still work as before and automatically register if possible. But on projects where that doesn't work out, initialize_filters() can now be called manually in a spot where WordPress initialization can be counted on having happened. I've included a README update to document this.