### PR TITLE
Update to use djboris88/twig-commented-include version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
 	},
 	"require": {
 		"php": ">=5.6",
-		"djboris88/twig-commented-include": "^1.2"
+		"djboris88/twig-commented-include": "^2.0"
 	}
 }


### PR DESCRIPTION
Update to use `djboris88/twig-commented-include` version 2 addling support for Timber V2.

Related PR from `twig-commented-include`:
https://github.com/djboris88/twig-commented-include/pull/1